### PR TITLE
AdminPage 등급 변경 및 변경 전 초기화 로직 구현 완료 / RankingPage 등수 처리 로직 구현 완료

### DIFF
--- a/src/components/Main/MyPage.tsx
+++ b/src/components/Main/MyPage.tsx
@@ -96,13 +96,14 @@ function MyPage() {
   //'운영진 페이지' 버튼 클릭시 수행할 함수
   function handleToAdminPageClick()
   {
-    if(userInfo.userRole === "ADMIN") //회원 정보가 운영진(ADMIN)일 경우
+    if(userInfo.userRole === "운영진") //회원 정보가 운영진(ADMIN)일 경우
     {
       alert("운영진으로 확인되셨습니다. 운영진 페이지로 이동합니다");
       navigate('/admin')
     }
     else //운영진 페이지에 접근 권한이 없는 사람이라면
     {
+      console.log(userInfo.userRole);
       alert("회원님은 운영진이 아니므로 해당 페이지에 접근 권한이 없으십니다!");
     }
   }

--- a/src/components/createAccount/TelNumberInput.tsx
+++ b/src/components/createAccount/TelNumberInput.tsx
@@ -7,7 +7,7 @@ import { RootState } from '../../redux/store'
 
 import customAxios from '../../apis/customAxios' //커스텀 axios 컴포넌트 가져오기
 
-//비밀번호를 입력하는 화면인 PasswordInput
+//전화번호 입력하는 화면인 TelNumberInput
 function TelNumberInput() {
   const navigate = useNavigate(); //제출 후에 다음 화면으로 넘어가기 위해 useNavigate() hook 활용!
 
@@ -23,7 +23,7 @@ function TelNumberInput() {
   };
 
   //서버에 회원가입 request 진행(POST 요청)
-  const signUpRequest = async () => {
+  const signUpRequest = async (phone: string) => {
 
     //post 요청 보낼 data 세팅
     const data = {
@@ -32,7 +32,7 @@ function TelNumberInput() {
       "name": signupState.name,
       "college": signupState.collegeName,
       "major": signupState.departmentName,
-      "phone": signupState.telNum
+      "phone": phone
     }
     
     console.log('구성된 데이터: ', data);
@@ -61,9 +61,8 @@ function TelNumberInput() {
     } else {
       alert("전화번호가 입력되었습니다. 이대로 진행합니다");
     }
-    dispatch(setTelNum(telNum)); //redux 저장소에 저장
     
-    signUpRequest(); //회원가입 수행
+    signUpRequest(telNum); //회원가입 수행
     
   };
 


### PR DESCRIPTION
<img width="590" alt="스크린샷 2025-03-04 21 55 40" src="https://github.com/user-attachments/assets/68c0e58b-e903-4173-994f-ade50c599135" />
<img width="180" alt="스크린샷 2025-03-04 21 55 19" src="https://github.com/user-attachments/assets/6d6883b5-ce45-4167-a683-ddb33f430467" />

## 주요 변경 사항
- AdminPage(운영진 페이지) 등급 변경 로직 추가
- 운영진 페이지에서 역할 변경 중 변경 전 초기 상태로 돌릴 수 있는 초기화 로직 구현 완료
- RankingPage(랭킹 페이지) API 연동 및 공동 순위 처리 로직 구현 완료

## 추후 계획
- 마이페이지 정보 수정 UI 추가 구현 및 API 연동 
- 프로필사진 연동 (현재는 userProfileImg 값이 null로 들어오게 처리되어 있음 / 이미지는 기본 프로필)

## 추가사항
- 요즘 과도하게 일들이 많이 겹쳐 손을 거의 못댔습니다 죄송합니다....ㅜㅜ
