### PR TITLE
FEAT & FIX: 랭킹페이지, 마이페이지 UI 렌더링 오류 수정 및 운영진 페이지 "페이서 여부" 수정 기능 추가

### DIFF
--- a/src/components/AdminPage/AdminPage.tsx
+++ b/src/components/AdminPage/AdminPage.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom'; // Link 컴포넌트 import
-import axios from 'axios';
-import customAxios from '../../apis/customAxios';
-import riku_logo from '../../assets/riku_logo_loginPage.svg'; //라이쿠 로고 불러오기
+import React, { useState, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom"; // Link 컴포넌트 import
+import axios from "axios";
+import customAxios from "../../apis/customAxios";
+import riku_logo from "../../assets/riku_logo_loginPage.svg"; //라이쿠 로고 불러오기
 
 //회원 정보와 관련된 객체 정보를 정의한 Member interface
 interface Member {
@@ -11,37 +11,42 @@ interface Member {
   college: string;
   major: string;
   phone: string | null;
-  point: number;
-  attendanceCount: number;
+  points: number;
+  participationCount: number;
   userRole: string;
+  isPacer: boolean;
 }
 
 //운영진 페이지
 //회원 정보를 모두 조회하고, 권한 변경 및 회원 삭제를 할 수 있는 API 필요
 function AdminPage() {
-
   const navigate = useNavigate(); //useNavigate 훅을 사용해 navigate 함수 생성
 
   //필요한 state 정의
   const [members, setMembers] = useState<Member[]>([]);
   const [editedMembers, setEditedMembers] = useState<Member[]>([]);
   const [roleChangedMembers, setRoleChangedMembers] = useState<Member[]>([]); //역할 바뀐 놈들 저장
-  const [sortConfig, setSortConfig] = useState<{ key: keyof Member; sortDirection: 'asc' | 'desc' } | null>(null);
+  const [sortConfig, setSortConfig] = useState<{
+    key: keyof Member;
+    sortDirection: "asc" | "desc";
+  } | null>(null);
 
   //회원 정보 불러올 함수 fetchMembers()
   async function fetchMembers() {
-    const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
-    const url = '/admin';
+    const accessToken = JSON.parse(localStorage.getItem("accessToken") || ""); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+    const url = "/admin";
 
     try {
       const response = await customAxios.get(
         url, //요청 url
         {
           headers: {
-            Authorization: accessToken //accessToken을 헤더로 추가해서 요청 보냄
-          }
+            Authorization: accessToken, //accessToken을 헤더로 추가해서 요청 보냄
+          },
         }
       );
+
+      console.log(response);
 
       let fetchedMembers = response.data.result.map((user: Member) => ({
         studentId: user.studentId,
@@ -49,17 +54,16 @@ function AdminPage() {
         college: user.college,
         major: user.major,
         phone: user.phone,
-        point: user.point,
-        attendanceCount: user.attendanceCount,
+        points: user.points,
+        participationCount: user.participationCount,
         userRole: user.userRole,
+        isPacer: false, //이 친구가 페이서인지 아닌지 판명
       }));
 
       setMembers(fetchedMembers);
       setEditedMembers(fetchedMembers);
-
-    } catch(error) {
-      alert('회원 정보를 가져 오는 데 실패했습니다')
-      
+    } catch (error) {
+      alert("회원 정보를 가져 오는 데 실패했습니다");
     }
   }
 
@@ -79,37 +83,76 @@ function AdminPage() {
 
     //이미 변경된 회원이 있다면 기존 정보를 제거하고 새 정보로 업데이트 해야 함
     const updatedRoleChangedMembers = roleChangedMembers.filter(
-      member => member.studentId !== changedMember.studentId
+      (member) => member.studentId !== changedMember.studentId
     );
     updatedRoleChangedMembers.push(changedMember);
 
     //상태 업데이트~
     setEditedMembers(updatedMembers);
     setRoleChangedMembers(updatedRoleChangedMembers);
+  }
+
+  //페이서 여부(isPacer)를 토글하기 위한 핸들러 함수 handlePacerToggle
+  const handlePacerToggle = (index: number) => {
+    const updatedMembers = [...editedMembers];
+    const changedMember = {
+      ...updatedMembers[index],
+      isPacer: !updatedMembers[index].isPacer,
+    };
+    updatedMembers[index] = changedMember;
+
+    //바뀐 멤버가 기존의 roleChangedMembers에 있는지 확인 후 추가 or 교체
+    const updatedRoleChanged = roleChangedMembers.filter(
+      (m) => m.studentId !== changedMember.studentId
+    );
+    updatedRoleChanged.push(changedMember);
+
+    //상태 업데이트
+    setEditedMembers(updatedMembers);
+    setRoleChangedMembers(updatedRoleChanged);
   };
+
+  //회원 정보 관련해서 분기 처리를 한 함수에서 처리해서 유틸 함수화
+  function compareValues(
+    a: string | number | boolean | null,
+    b: string | number | boolean | null,
+    direction: "asc" | "desc"
+  ) {
+    //telNum 옵션에서 null이 발생할 수 있음, 이에 대해선 예외 처리를 해주어야 함
+    if (a === null || b === null) return a === b ? 0 : a === null ? 1 : -1;
+
+    // boolean 처리
+    if (typeof a === "boolean" && typeof b === "boolean") {
+      const aNum = a ? 1 : 0;
+      const bNum = b ? 1 : 0;
+      return direction === "asc" ? aNum - bNum : bNum - aNum;
+    }
+
+    // 타입 안전한 비교 (number vs string)
+    if (typeof a === "number" && typeof b === "number") {
+      return direction === "asc" ? a - b : b - a;
+    }
+
+    // 문자열 비교 (localeCompare로 안정성 확보한다 --> 다국어 문자열 비교 지원을 하나, 성능이 부등호 보단 다소 느릴 수 있음)
+    return direction === "asc"
+      ? String(a).localeCompare(String(b))
+      : String(b).localeCompare(String(a));
+  }
 
   //회원 정보들을 정렬하기 위한 handleSort
   function handleSort(key: keyof Member) {
-    let sortDirection: 'asc' | 'desc' = 'asc'; //내림차순(desc) 혹은 오름차순(asc) 옵션 관련한 자료형 sortDirection 선언
+    let sortDirection: "asc" | "desc" = "asc"; //내림차순(desc) 혹은 오름차순(asc) 옵션 관련한 자료형 sortDirection 선언
 
-    //sortConfig 값이 null이 아니라면, sortDirection을 반전 시킨다 
-    if (sortConfig && sortConfig.key === key && sortConfig.sortDirection === 'asc') {
-      sortDirection = 'desc';
+    //sortConfig 값이 null이 아니라면, sortDirection을 반전 시킨다
+    if (sortConfig && sortConfig.key === key && sortConfig.sortDirection === "asc") {
+      sortDirection = "desc";
     }
 
     const sortedMembers = [...editedMembers].sort((a, b) => {
       const aValue = a[key];
       const bValue = b[key];
-      
-      //telNum 옵션에서 null이 발생할 수 있음, 이에 대해선 예외 처리를 해주어야 함
-      if (aValue === null || bValue === null) {
-        return aValue === bValue ? 0 : aValue === null ? 1 : -1;
-      }
 
-      //값에 따라 -1, 0, 1중 1개의 값 반환 (정렬 방향 속성 고려)
-      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-      return 0;
+      return compareValues(aValue, bValue, sortDirection); //해당 함수를 통해 number, string 둘 다에 대해 정렬 가능
     });
 
     setEditedMembers(sortedMembers);
@@ -117,75 +160,90 @@ function AdminPage() {
   }
 
   //저장하는 프로세스를 핸들링하는 메소드 handleSave
-  async function handleSave(){
+  async function handleSave() {
     try {
-      const accessToken = JSON.parse(localStorage.getItem('accessToken') || ''); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
-      const url = '/admin';
+      const accessToken = JSON.parse(localStorage.getItem("accessToken") || ""); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
+      const url = "/admin";
       //roleChangedMembers 배열의 요소들에서 studentId, userName만을 추출
-      const payload = roleChangedMembers.map(({studentId, userRole}) => ({ studentId, userRole }));
+      const payload = roleChangedMembers.map(({ studentId, userRole, isPacer }) => ({
+        studentId,
+        userRole,
+        isPacer,
+      }));
       console.log("바뀐 회원 정보: ", payload);
       //바뀐 친구가 없다면(roleChangedMembers에 들어간 놈이 아무것도 없다면..)
-      if(payload.length === 0) {
-        alert('현재 바뀐 정보가 없습니다.');
+      if (payload.length === 0) {
+        alert("현재 바뀐 정보가 없습니다.");
       } else {
-        await customAxios.put(
-          url, 
-          payload,
-          {
-            headers: {
-              Authorization: accessToken //accessToken을 헤더로 추가해서 요청 보냄
-            }
-          }
-        ); //추후 해당하는 api 엔드포인트로 교체할 예정
-        alert('성공적으로 회원 정보 수정이 완료 되었습니다!');
-        navigate('/tab/my-page')
+        await customAxios.patch(url, payload, {
+          headers: {
+            Authorization: accessToken, //accessToken을 헤더로 추가해서 요청 보냄
+          },
+        }); //추후 해당하는 api 엔드포인트로 교체할 예정
+        alert("성공적으로 회원 정보 수정이 완료 되었습니다!");
+        navigate("/tab/my-page");
       }
     } catch (error) {
-      console.error('수정 사항을 저장하는 데 오류가 발생했습니다', error);
-      alert('수정 사항을 저장하는 데 오류가 발생했습니다!');
+      console.error("수정 사항을 저장하는 데 오류가 발생했습니다", error);
+      alert("수정 사항을 저장하는 데 오류가 발생했습니다!");
     }
-  };
+  }
 
   //editedMembers state를 초기화하는 프로세스를 핸들링하는 메소드 handleReset
   function handleReset() {
     setEditedMembers([...members]);
-  };
+  }
 
   //마이 페이지로 돌아가는 버튼
   function handleToMyPage() {
-    navigate('/tab/my-page')
+    navigate("/tab/my-page");
   }
 
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center mb-8">
-        <img src={riku_logo} alt="Logo" className="h-10 mr-4"/>
+        <img src={riku_logo} alt="Logo" className="h-10 mr-4" />
         <span className="text-2xl font-bold">회원 정보 관리</span>
       </div>
       <div className="flex items-center ml-4 mbs-4">
-        <span className="text-sm font-bold">참고 사항: 표의 제목을 누르실 경우, 각 항목에 대해 정렬하여 조회하실 수 있습니다</span>
+        <span className="text-sm font-bold">
+          참고 사항: 표의 제목을 누르실 경우, 각 항목에 대해 정렬하여 조회하실 수 있습니다
+        </span>
       </div>
       <div className="overflow-x-auto">
         <table className="table-auto w-[1220px] text-left border-collapse">
           {/*표 상단의 header 부분 렌더링*/}
           <thead>
             <tr>
-              {['학번', '이름', '단과대학명', '전공명', '전화번호', '포인트', '활동내역 갯수', '회원등급'].map((header, index) => (
+              {[
+                "학번",
+                "이름",
+                "단과대학명",
+                "전공명",
+                "전화번호",
+                "포인트",
+                "활동내역 갯수",
+                "회원등급",
+                "페이서 여부",
+              ].map((header, index) => (
                 <th
                   key={index}
                   className="px-4 py-2 border-b cursor-pointer"
-                  onClick={() => handleSort(
-                    [
-                      'studentId',
-                      'userName',
-                      'college',
-                      'major',
-                      'phone',
-                      'point',
-                      'attendanceCount',
-                      'userRole',
-                    ][index] as keyof Member
-                  )}
+                  onClick={() =>
+                    handleSort(
+                      [
+                        "studentId",
+                        "userName",
+                        "college",
+                        "major",
+                        "phone",
+                        "points",
+                        "participationCount",
+                        "userRole",
+                        "isPacer",
+                      ][index] as keyof Member
+                    )
+                  }
                 >
                   {header}
                 </th>
@@ -201,8 +259,8 @@ function AdminPage() {
                 <td className="px-4 py-2 border-b">{member.college}</td>
                 <td className="px-4 py-2 border-b">{member.major}</td>
                 <td className="px-4 py-2 border-b">{member.phone}</td>
-                <td className="px-4 py-2 border-b">{member.point}</td>
-                <td className="px-4 py-2 border-b">{member.attendanceCount}</td>
+                <td className="px-4 py-2 border-b">{member.points}</td>
+                <td className="px-4 py-2 border-b">{member.participationCount}</td>
                 <td className="px-4 py-2 border-b">
                   <select
                     value={member.userRole}
@@ -214,6 +272,14 @@ function AdminPage() {
                     <option value="ADMIN">운영진</option>
                     <option value="INACTIVE">비활성화 사용자</option>
                   </select>
+                </td>
+                <td className="px-4 py-2 border-b text-center">
+                  <input
+                    type="checkbox"
+                    checked={member.isPacer}
+                    onChange={() => handlePacerToggle(index)}
+                    className="w-4 h-4 mr-2 accent-kuDarkGreen"
+                  />
                 </td>
               </tr>
             ))}
@@ -242,7 +308,7 @@ function AdminPage() {
         </button>
       </div>
     </div>
-  )
+  );
 }
 
 export default AdminPage;

--- a/src/components/Main/MyPage.tsx
+++ b/src/components/Main/MyPage.tsx
@@ -189,7 +189,8 @@ function MyPage() {
       );
       alert(response.data.result.message); //"출석이 완료되었습니다"가 출력될 것
       console.log("출석 완료, 불러오기 성공: ", response); //test용
-      setAttendChecked(!attendChecked); //'출석됨'으로 표시
+      setAttendChecked(true); //'출석됨'으로 표시
+      await fetchUserInfo(); //여기에서 유저 정보를 갱신하는 함수(fetchUserInfo)를 call해야 캘린더에 반영된다
     } catch (error) {
       alert("출석 요청 중 오류 발생!");
       console.error("요청 실패: ", error);
@@ -213,7 +214,7 @@ function MyPage() {
     fetchUserInfo();
   }, []);
 
-  //userInfo가 정상적으로 업데이트 되었을 시에만 출석 검사 수행
+  //userInfo가 정상적으로 업데이트 되었을 시에만 출석 검사 수행 ('출석하기' 버튼 클릭 후, attendChecked가 변했을 때에도 다시 수행해야 함)
   useEffect(() => {
     if (userInfo.profileAttendanceDates.length > 0) {
       //profileAttendanceDates가 비어있지 않은 경우에만 수행
@@ -288,7 +289,7 @@ function MyPage() {
       {/* 오늘의 출석 세션 */}
       <div className="bg-whiteSmoke p-4 rounded-xl w-full max-w-sm text-center items-center">
         <p className="text-lg font-extrabold text-gray-800">오늘의 출석</p>
-        <p className="text-sm text-gray-500">출석하면 +5P!</p>
+        <p className="text-sm text-gray-500">출석하면 +1P!</p>
 
         {/* 중첩 map 함수를 사용해서 출석체크 달력을 출력할 것이다(캘린더 렌더링) */}
         {weeks.map((week, index) => (

--- a/src/components/Main/RankingPage.tsx
+++ b/src/components/Main/RankingPage.tsx
@@ -203,8 +203,9 @@ function RankingPage() {
               </div>
             </div>
           ) : (
-            <span className="text-3xl font-extrabold text-white mt-8 mb-8 animate-fade-up animation-delay-400 opacity-0">
+            <span className="w-[375px] mx-auto text-center text-3xl font-extrabold text-white mt-8 mb-8 animate-fade-up animation-delay-400 opacity-0">
               집계 준비중입니다..
+              {/* 현재는 우선 375px 크기로 너비를 고정해 놓은 상태, 추후 반응형 설계를 위해 수정해야 할 듯 */}
             </span>
           )}
         </div>


### PR DESCRIPTION
## 주요 변경사항
- 랭킹페이지, 마이페이지 UI가 찌그러 지거나, 출석 여부가 캘린더에 바로 반영이 되지 않는 여러 자잘한 이슈 수정
- 운영진 페이지에 "페이서 여부" 수정 기능 추가 (추가적으로, '포인트', '활동 내역 개수', '페이서 여부'에 따른 정렬 기능 추가)
- 기타 잠수함 패치

## 리뷰 요구사항
- 현재는 운영진 페이지에서 초반에 회원 리스트를 불러올 때, 페이서 여부(isPacer)를 불러오지 못합니다. 백엔드 측에서, 해당 정보를 같이 담아서 보내 주셔야 할 것 같아요. (저희 Notion의 QA 게시판에 해당 내용 올려 놓았습니다)
- 제가 수정한 부분에서 여러분께서 현재 구현 중인 부분이 겹쳐서 수정 되었는지 확인 부탁드립니다.

## 스크린샷
<img width="250" alt="스크린샷 2025-04-13 15 26 46" src="https://github.com/user-attachments/assets/b1031eb0-d2df-449f-9a0e-c80f4dbcb413" />
<img width="250" alt="스크린샷 2025-04-13 15 27 06" src="https://github.com/user-attachments/assets/535c51b4-c0cd-410c-a227-67a7f185b963" />
<img width="250" alt="스크린샷 2025-04-13 15 50 58" src="https://github.com/user-attachments/assets/03c05cd5-6625-4985-bd32-868a72e04913" />

## 건의사항
- 항상 고생 많으십니다 여러분.