### PR TITLE
FEAT & FIX: 프로필 사진 업로드 시 자동 압축(1MB 이내로), 일정 페이지(SchedulePage.tsx) 수정 및 최종 배포를 위한 console.log() 제거

### DIFF
--- a/src/components/AdminPage/AdminPage.tsx
+++ b/src/components/AdminPage/AdminPage.tsx
@@ -45,8 +45,6 @@ function AdminPage() {
         }
       );
 
-      console.log("요청 성공", response.data);
-
       let fetchedMembers = response.data.result.map((user: Member) => ({
         studentId: user.studentId,
         userName: user.userName,
@@ -70,7 +68,6 @@ function AdminPage() {
   useEffect(() => {
     // setMembers(dummyData);
     // setEditedMembers(dummyData);
-    console.log("바뀐 놈: ", editedMembers);
     fetchMembers();
   }, []);
 
@@ -169,7 +166,6 @@ function AdminPage() {
         userRole,
         isPacer,
       }));
-      console.log("바뀐 회원 정보: ", payload);
       //바뀐 친구가 없다면(roleChangedMembers에 들어간 놈이 아무것도 없다면..)
       if (payload.length === 0) {
         alert("현재 바뀐 정보가 없습니다.");

--- a/src/components/Login/LoginPage.tsx
+++ b/src/components/Login/LoginPage.tsx
@@ -52,7 +52,6 @@ function LoginPage() {
       const response = await customAxios.post(url, data);
       // 성공적인 응답 처리
       if (response.data.isSuccess) {
-        console.log(response.data.result.jwtInfo.accessToken);
         alert(`로그인에 성공했습니다! 회원의 학번: ${response.data.result.studentId}`);
 
         localStorage.setItem(
@@ -60,7 +59,6 @@ function LoginPage() {
           JSON.stringify(response.data.result.jwtInfo.accessToken)
         );
         localStorage.setItem("MyId", JSON.stringify(response.data.result.userId));
-        console.log(response.data);
         navigate("/tab/main"); // 로그인 성공 시 메인 페이지로 이동
       } else {
         // 요청 실패 처리

--- a/src/components/Main/ActivityDetailPage.tsx
+++ b/src/components/Main/ActivityDetailPage.tsx
@@ -72,7 +72,6 @@ function ActivityDetailPage() {
           Authorization: accessToken,
         },
       });
-      console.log(response.data.result);
       setUserData(response.data.result); //불러온 값(response.data.result)으로 userData를 세팅!
     } catch (error) {
       console.error("프로필 불러오기 실패:", error);

--- a/src/components/Main/MyPage.tsx
+++ b/src/components/Main/MyPage.tsx
@@ -120,7 +120,6 @@ function MyPage() {
         }
       );
 
-      console.log("유저 프로필 불러오기 성공: ", response); //test용
       if (response.data.isSuccess === true) {
         let formattedUserRole = getUserRole(response.data.result.userRole);
         let data = {
@@ -166,7 +165,6 @@ function MyPage() {
       navigate("/admin");
     } //운영진 페이지에 접근 권한이 없는 사람이라면
     else {
-      console.log(userInfo.userRole);
       alert("회원님은 운영진이 아니므로 해당 페이지에 접근 권한이 없으십니다!");
     }
   }
@@ -180,7 +178,6 @@ function MyPage() {
   async function handleAttendCheckBtn() {
     const accessToken = JSON.parse(localStorage.getItem("accessToken") || ""); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
     const url = `/user/attend`;
-    console.log(accessToken); //테스팅용
 
     try {
       const response = await customAxios.post(
@@ -192,9 +189,7 @@ function MyPage() {
           },
         }
       );
-      console.log(response.data);
       alert("출석이 완료됨!"); //"출석이 완료되었습니다"가 출력될 것
-      console.log("출석 완료, 불러오기 성공: ", response); //test용
       setAttendChecked(true); //'출석됨'으로 표시
       await fetchUserInfo(); //여기에서 유저 정보를 갱신하는 함수(fetchUserInfo)를 call해야 캘린더에 반영된다
     } catch (error) {
@@ -226,10 +221,6 @@ function MyPage() {
       //profileAttendanceDates가 비어있지 않은 경우에만 수행
       const formattedDate = format(new Date(), "yyyy-MM-dd"); // 오늘 날짜를 formattedDate로 포맷팅
       let isTodayAttended = userInfo.profileAttendanceDates.includes(formattedDate);
-      console.log(
-        "userInfo 업데이트 되고, profile 이거 배열 0보다 큼, isTodayAttended: ",
-        isTodayAttended
-      );
       if (isTodayAttended) {
         // 오늘 날짜가 출석되어 있다면
         setAttendChecked(true); // 출석 더 이상 못하게 한다

--- a/src/components/Main/ProfileFixPage.tsx
+++ b/src/components/Main/ProfileFixPage.tsx
@@ -1,13 +1,10 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom"; // Link 컴포넌트 import
-import profile_Img from "../../assets/default_profile.png"; //이미지 불러오기
-import rightArrow_Icon from "../../assets/right_arrow.svg"; //라이쿠 로고 불러오기
 import customAxios from "../../apis/customAxios";
-import duganadi_Img from "../../assets/RankingPage/dueganadi.png"; //이미지 불러오기
 import pencil_Icon from "../../assets/Main-img/pencil.svg"; //연필 로고 불러오기
-import arrowDown_Icon from "../../assets/Main-img/arrow_down.svg"; //아래쪽 화살표 로고 불러오기
 import ActionBar from "../../components/ActionBar";
 import defaultProfileImg from "../../assets/default_profile.png";
+import imageCompression from "browser-image-compression"; //이미지 압축을 위한 라이브러리 추가
 
 import EyeIcon from "../../assets/visibility_true.svg";
 import EyeOffIcon from "../../assets/visibility_false.svg";
@@ -153,8 +150,6 @@ function ProfileFixPage() {
     if (selectedImage) formData.append("userProfileImg", selectedImage);
     if (password !== "") formData.append("password", password); //비밀번호가 공백이라면, 빈 채로 보내줘야 함
 
-    console.log("FormData 내용:", Array.from(formData.entries()));
-
     try {
       const accessToken = JSON.parse(localStorage.getItem("accessToken") || ""); //localStorage에 저장된 accessToken 값이 없으면 ''으로 초기화
       const url = `/user/profile`;
@@ -167,11 +162,9 @@ function ProfileFixPage() {
 
       //성공했다면
       if (response.data.isSuccess) {
-        console.log("프로필 수정 성공: ", response.data);
         alert("프로필 수정에 성공했습니다.");
         navigate("/tab/my-page");
       } else {
-        console.log("요청 값이 잘못됨");
         alert(response.data.errors.message);
       }
     } catch (error) {
@@ -183,17 +176,30 @@ function ProfileFixPage() {
   const MAX_FILE_SIZE = 3 * 1024 * 1024; // 업로드 최대 가능 용량: 3MB로 우선 하드코딩
 
   //파일 선택 시 -> file 객체 상태에 저장 + 미리보기 URL 생성하는 메소드 handleFileChange
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) {
-      //최대 용량을 넘어갈 경우
-      if (file.size > MAX_FILE_SIZE) {
-        alert("업로드 가능한 사진 크기는 최대 3MB입니다.");
+    if (!file) return; //file이 null일 경우, return
+
+    try {
+      const options = {
+        maxSizeMB: 1, //최대 1MB 목표 (가볍게 하려면 추후 0.5로도 가능할 듯)
+        maxWidthOrHeight: 512, //가로/세로 길이 제한
+        useWebWorker: true,
+        fileType: "image/webp", //변환 포맴ㅅ 지정 (브라우저 지원 범위 고려해서..)
+      };
+
+      const compressedFile = await imageCompression(file, options); //압축할 것임
+
+      // 압축 후에도 3MB를 초과한다면 업로드 금지
+      if (compressedFile.size > MAX_FILE_SIZE) {
+        alert("압축 후에도 파일이 너무 큽니다. 다른 파일을 선택해 주세요.");
         return;
       }
-
-      setSelectedImage(file);
-      setPreviewUrl(URL.createObjectURL(file)); // 미리보기용 URL 생성
+      setSelectedImage(compressedFile);
+      setPreviewUrl(URL.createObjectURL(compressedFile)); // 미리보기용 URL 생성
+    } catch (error) {
+      console.error("이미지 압축 실패: ", error);
+      alert("이미지 압축하는 도중에 오류가 발생함!");
     }
   };
 
@@ -223,7 +229,6 @@ function ProfileFixPage() {
           Authorization: accessToken,
         },
       });
-      console.log(response.data.result);
 
       //400, 405, 500 오류일 경우, catch가 잡아줄 것이므로 따로 예외처리할 필요 없을 듯
       setName(response.data.result.name);

--- a/src/components/Main/RankingPage.tsx
+++ b/src/components/Main/RankingPage.tsx
@@ -56,8 +56,6 @@ function RankingPage() {
         }
       );
 
-      console.log(response);
-
       //공동 순위 처리에 용이하도록 userId는 서버에서 받아온 정보가 아닌 순위대로 ++하는 idx로 선언(추후 공동 순위 처리 로직이 추가로 삽입됨)
       let idx: number = 1;
 

--- a/src/components/Main/SchedulePage.tsx
+++ b/src/components/Main/SchedulePage.tsx
@@ -114,7 +114,6 @@ function SchedulePage() {
           },
         }
       );
-      console.log(response.data);
       setMonthlyPlan(response.data.result.schedules); //불러온 data의 result 값으로 monthlyPlan 값 저장
 
     } catch (error) {
@@ -154,7 +153,6 @@ function SchedulePage() {
         }
       );
       setSelectedDateEvent(response.data.result); //불러온 data의 result 값으로 selectedDateEvent 값 저장
-      console.log("일별 데이터 응답 성공: ", response.data);
     } catch (error) {
       alert("서버 요청 중 오류 발생!");
       console.error("요청 실패: ", error);
@@ -221,7 +219,9 @@ function SchedulePage() {
       //모달 내에서 현재 선택된 날짜(selectedDateInModal)가 pointDateInModal과 다른 경우
       newDate.setFullYear(pointDateInModal.getFullYear()); //newDate의 연도 값도 바꿔줘야 한다
     }
-    setSelectedDateInModal(newDate); //모달창 내부에서 선택한 날짜에 대한 정보를 바꿔줘야 한다.
+    setPointDate(newDate); //안에서 선택한 연/월을 바깥의 pointDate로 설정한다
+    setIsModalOpen(false); //누르자마자 모달창 닫도록 설정
+    // setSelectedDateInModal(newDate); //모달창 내부에서 선택한 날짜에 대한 정보를 바꿔줘야 한다.
   };
 
   const handleDateClick = (date: Date) => {

--- a/src/components/createAccount/StudentidInput.tsx
+++ b/src/components/createAccount/StudentidInput.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom'; //react-router-dom 라이브러리를 사용 (useNavigation 사용할 예정)
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom"; //react-router-dom 라이브러리를 사용 (useNavigation 사용할 예정)
 
-import { useDispatch } from 'react-redux'; 
-import { setStudentID } from '../../redux/slices/signupSlice' //Action Creator를 import 해온다!
+import { useDispatch } from "react-redux";
+import { setStudentID } from "../../redux/slices/signupSlice"; //Action Creator를 import 해온다!
 
-import axios from 'axios'; //axios(서버와의 통신을 위한 라이브러리) import!
-import customAxios from '../../apis/customAxios';
+import axios from "axios"; //axios(서버와의 통신을 위한 라이브러리) import!
+import customAxios from "../../apis/customAxios";
 
 //학번의 유효성을 검사하는 메소드 validateStudentID
 function validateStudentID(id: string) {
@@ -50,23 +50,25 @@ function StudentidInput() {
       //학번 중복 확인을 서버 요청을 통해 먼저 진행해야 한다 (try-catch 구문 활용)
       try {
         const response = await customAxios.get(`/user/check-id?studentId=${studentID}`);
-        console.log("결과: ", response);
         //중복 확인 검사 성공했을 경우에만 (result 값이 false여야 함)
-        if(response.data.result === false) {
+        if (response.data.result === false) {
           alert("학번이 유효합니다! 다음 단계로 넘어갑니다.");
           //redux 저장소에 studentID 저장
           dispatch(setStudentID(studentID));
-          navigate('/password-input'); //'/next-step'라는 값을 가진 컴포넌트로 이동한다 (navigating)
+          navigate("/password-input"); //'/next-step'라는 값을 가진 컴포넌트로 이동한다 (navigating)
         } else {
           //중복 검사 실패 (겹치는 놈 있음)
-          alert('이미 가입된 학번입니다. 다른 학번으로 가입을 다시 시도해 주세요.');
+          alert("이미 가입된 학번입니다. 다른 학번으로 가입을 다시 시도해 주세요.");
         }
-      } catch(error) {
+      } catch (error) {
         // 오류가 발생한 경우 처리
         if (axios.isAxiosError(error)) {
-          alert('An error occurred while validating the Login ID: ' + (error.response?.data?.message || error.message));
+          alert(
+            "An error occurred while validating the Login ID: " +
+              (error.response?.data?.message || error.message)
+          );
         } else {
-          alert('An unexpected error occurred');
+          alert("An unexpected error occurred");
         }
       }
     } else {
@@ -83,14 +85,14 @@ function StudentidInput() {
         </button>
         <span className="text-gray-400 text-sm">1/5</span>
       </div>
-  
+
       {/* Main Form */}
       <form onSubmit={handleSubmit} className="w-full max-w-sm mt-16">
         {/* '아이디를 입력해 주세요' 텍스트 */}
         <div className="w-full max-w-sm">
           <h1 className="text-left font-bold text-2xl text-black mb-12">학번을 입력해 주세요.</h1>
         </div>
-  
+
         {/* 학번 입력 필드 */}
         <div className="mb-6">
           <input
@@ -98,17 +100,29 @@ function StudentidInput() {
             value={studentID}
             onChange={handleChange}
             placeholder="학번(StudentID)"
-            className={`w-full px-4 py-2 border ${studentID === '' ? 'border-gray-300' : isValidID ? 'border-gray-300' : 'border-red-500'} rounded-md focus:outline-none`}
+            className={`w-full px-4 py-2 border ${
+              studentID === ""
+                ? "border-gray-300"
+                : isValidID
+                ? "border-gray-300"
+                : "border-red-500"
+            } rounded-md focus:outline-none`}
           />
           <div className="w-full max-w-sm">
-            {!(isValidID || studentID === '') && <p className="text-red-500 text-sm mt-2 text-left">{validationMessage}</p>}
+            {!(isValidID || studentID === "") && (
+              <p className="text-red-500 text-sm mt-2 text-left">{validationMessage}</p>
+            )}
           </div>
         </div>
 
         {/* 다음 버튼 */}
         <button
           type="submit"
-          className={`w-full py-3 mt-72 rounded-md ${isValidID ? 'bg-kuDarkGreen text-kuWhite hover: hover:bg-kuGreen' : ' text-gray-500 bg-gray-100'} transition-colors`}
+          className={`w-full py-3 mt-72 rounded-md ${
+            isValidID
+              ? "bg-kuDarkGreen text-kuWhite hover: hover:bg-kuGreen"
+              : " text-gray-500 bg-gray-100"
+          } transition-colors`}
           disabled={!isValidID}
         >
           다음
@@ -119,7 +133,6 @@ function StudentidInput() {
       <div className="mb-4"></div>
     </div>
   );
-  
 }
 
 export default StudentidInput;

--- a/src/components/createAccount/TelNumberInput.tsx
+++ b/src/components/createAccount/TelNumberInput.tsx
@@ -1,17 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import { UNSAFE_ErrorResponseImpl, useNavigate } from 'react-router-dom'; //react-router-dom 라이브러리를 사용 (useNavigation 사용할 예정)
+import React, { useState, useEffect } from "react";
+import { UNSAFE_ErrorResponseImpl, useNavigate } from "react-router-dom"; //react-router-dom 라이브러리를 사용 (useNavigation 사용할 예정)
 
-import { useDispatch, useSelector} from 'react-redux'; //상태값을 가져오기 위해 useSelector 사용
-import { setTelNum } from '../../redux/slices/signupSlice' //Action Creator를 import 해온다!
-import { RootState } from '../../redux/store'
+import { useDispatch, useSelector } from "react-redux"; //상태값을 가져오기 위해 useSelector 사용
+import { setTelNum } from "../../redux/slices/signupSlice"; //Action Creator를 import 해온다!
+import { RootState } from "../../redux/store";
 
-import customAxios from '../../apis/customAxios' //커스텀 axios 컴포넌트 가져오기
+import customAxios from "../../apis/customAxios"; //커스텀 axios 컴포넌트 가져오기
 
 //전화번호 입력하는 화면인 TelNumberInput
 function TelNumberInput() {
   const navigate = useNavigate(); //제출 후에 다음 화면으로 넘어가기 위해 useNavigate() hook 활용!
 
-  const [telNum, setTelNumInput] = useState<string>(''); //전화번호를 저장하는 state
+  const [telNum, setTelNumInput] = useState<string>(""); //전화번호를 저장하는 state
 
   const dispatch = useDispatch(); //redux 사용을 위해 useDispatch 활용
   const signupState = useSelector((state: RootState) => state.signup); //상태값 가져오기
@@ -24,46 +24,41 @@ function TelNumberInput() {
 
   //서버에 회원가입 request 진행(POST 요청)
   const signUpRequest = async (phone: string) => {
-
     //post 요청 보낼 data 세팅
     const data = {
-      "studentId" : signupState.studentID,
-      "password": signupState.password,
-      "name": signupState.name,
-      "college": signupState.collegeName,
-      "major": signupState.departmentName,
-      "phone": phone === '' ? null : phone // 전화번호(phone) 값이 비어있는 경우엔 null을 반환
-    }
-    
-    console.log('구성된 데이터: ', data);
+      studentId: signupState.studentID,
+      password: signupState.password,
+      name: signupState.name,
+      college: signupState.collegeName,
+      major: signupState.departmentName,
+      phone: phone === "" ? null : phone, // 전화번호(phone) 값이 비어있는 경우엔 null을 반환
+    };
 
     //해당 구역에 axios 요청을 진행할 것임(서버에 입력된 회원 정보를 저장해야 함)
     try {
-      const response = await customAxios.post('/user/signup', data)
-      if(response.data.isSuccess === true)
-      {
-        alert('정상적으로 회원 가입이 완료되었습니다');
-        navigate('/'); //'/next-step'라는 값을 가진 컴포넌트로 이동한다 (navigating)
-      } else if(response.data.isSuccess === false) {
+      const response = await customAxios.post("/user/signup", data);
+      if (response.data.isSuccess === true) {
+        alert("정상적으로 회원 가입이 완료되었습니다");
+        navigate("/"); //'/next-step'라는 값을 가진 컴포넌트로 이동한다 (navigating)
+      } else if (response.data.isSuccess === false) {
         alert(response.data.responseMessage);
       }
     } catch (error) {
       alert(error);
     }
-  }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
     //전화번호 입력 후 '다음' 버튼을 입력했을 경우(해당 경우에 대해서는 axios 요청을 진행해야 함)
-    if (telNum === '') {
+    if (telNum === "") {
       alert("전화번호가 입력되지 않았습니다. 그대로 진행합니다");
     } else {
       alert("전화번호가 입력되었습니다. 이대로 진행합니다");
     }
-    
+
     signUpRequest(telNum); //회원가입 수행
-    
   };
 
   return (
@@ -76,16 +71,18 @@ function TelNumberInput() {
         <span className="text-gray-400 text-sm">5/5</span>
       </div>
 
-      
-  
       {/* Main Form */}
       <form onSubmit={handleSubmit} className="w-full max-w-sm mt-16">
         {/* '아이디를 입력해 주세요' 텍스트 */}
         <div className="w-full max-w-sm">
-          <h1 className="text-left font-bold text-2xl text-black mt-12">전화번호를 입력해 주세요.</h1>
-          <h3 className="text-left font-medium text-sm text-gray-500 mb-12">전화번호 입력은 선택 사항입니다(ex. 010-1111-1111)</h3>
+          <h1 className="text-left font-bold text-2xl text-black mt-12">
+            전화번호를 입력해 주세요.
+          </h1>
+          <h3 className="text-left font-medium text-sm text-gray-500 mb-12">
+            전화번호 입력은 선택 사항입니다(ex. 010-1111-1111)
+          </h3>
         </div>
-  
+
         {/* 전화번호 필드 */}
         <div className="mb-6">
           <input
@@ -110,7 +107,6 @@ function TelNumberInput() {
       <div className="mb-4"></div>
     </div>
   );
-  
 }
 
 export default TelNumberInput;


### PR DESCRIPTION
## 주요 변경사항
- 프로필 수정 페이지(ProfileFixPage.tsx)에서 프로필 사진 업로드 시, 자동으로 1MB 이내로 압축하고, webp 형태로 변환되어 저장될 수 있는 기능 추가 (browser-image-compression 라이브러리 추가 및 활용) -> **이를 통해 사진 갤러리의 아무 사진 첨부 가능**
- 일정 페이지(SchedulePage.tsx)에서 연/월을 선택하는 모달창에서 월 선택 시, 바로 모달창이 닫히도록 수정
- 최종 배포를 위해, 구현 시 디버깅을 하려고 적어 놨던 console.log() 모두 삭제 (삭제한 곳: AdminPage, createAccount, Login, Main)

## 리뷰 요구사항
- 제가 추가한 browser-image-compression 라이브러리가 다른 라이브러리 및 구현부와 충돌이 나지 않는지 검토해 주세요.
- 최종 출시 전 제가 구현한 부분이 문제가 없는지 점검해 주세요.

## 스크린샷
<img width="300" alt="스크린샷 2025-04-27 10 42 27" src="https://github.com/user-attachments/assets/66dba835-a8b2-4bbc-a0c7-5272790a4c65" />
<img width="300" alt="스크린샷 2025-04-27 10 29 56" src="https://github.com/user-attachments/assets/7891bcf3-d2eb-4505-8e2e-188592f4eccc" />

## 건의사항
- 내일 정규런 주페이서는 누구?