### PR TITLE
FIX: 프로필 수정 화면에서 전화번호만 수정 시 '저장하기' 버튼이 활성화 안되던 문제 해결

### DIFF
--- a/src/components/Main/ProfileFixPage.tsx
+++ b/src/components/Main/ProfileFixPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom"; // Link 컴포넌트 import
 import customAxios from "../../apis/customAxios";
 import pencil_Icon from "../../assets/Main-img/pencil.svg"; //연필 로고 불러오기
@@ -123,6 +123,7 @@ function ProfileFixPage() {
   const [collegeName, setCollegeName] = useState("공과대학"); //학교 정보-단과대명
   const [departmentName, setDepartmentName] = useState("힙합공학부"); //학교 정보-학과명
   const [telNum, setTelNum] = useState(""); //전화번호
+  const [telNumChanged, setTelNumChanged] = useState(false); //전화번호가 바뀌었는지 확인하는 state
   const [studentID, setStudentID] = useState("201911291"); //학번(ID)
   const [userProfileImageUrl, setUserProfileImageUrl] = useState(""); //유저 프로필 이미지 url
 
@@ -203,12 +204,20 @@ function ProfileFixPage() {
     }
   };
 
+  //핸드폰 번호의 정보가 바뀌었을 때 바뀌었다는 것을 표시하기 위한 handleTelNumChanged
+  const handleTelNumChanged = useCallback((value: string) => {
+    if (!telNumChanged) {
+      setTelNumChanged(true); //전화번호가 바뀌었다고 표시한다
+    }
+    setTelNum(value);
+  }, []);
+
   //저장하기 전에 필수 form이 다 채워졌나 확인하는 변수들 (전화번호를 제외한 모든 form이 채워져 있어야 함), 그리고 이를 검증하는 isFormsValid() 함수
   const isPasswordFormValid = password.trim() === "" || isPasswordValid;
 
   function isFormsValid() {
     //비번도 비어있는 상태이고, 프사 선택도 안했다면, 가차없이 false 반환
-    if (password.trim() === "" && selectedImage === null) return false;
+    if (password.trim() === "" && selectedImage === null && telNumChanged === false) return false;
 
     if (isPasswordFormValid) {
       //비밀번호가 유효한 경우
@@ -303,7 +312,7 @@ function ProfileFixPage() {
             <InputField
               label="전화번호"
               value={telNum}
-              onChange={setTelNum}
+              onChange={handleTelNumChanged}
               placeholder="ex) 010-1111-2222"
             />
             <InputField label="학번(ID)" value={studentID} onChange={setStudentID} disabled />


### PR DESCRIPTION
## 주요 변경사항
- 프로필 수정 화면(ProfileFixPage.tsx)에서 전화번호만 수정 시, '저장하기' 버튼 활성화 안되던 문제 해결
- 자잘한 버그 fix 및 코드 리팩토링

## 리뷰 요구사항
- 제가 변경한 부분이 여러분이 변경한 곳과 겹치는 곳이 있는지 확인해 주세요

## 스크린샷
<img width="340" alt="스크린샷 2025-04-28 01 53 56" src="https://github.com/user-attachments/assets/64b072e3-8e37-489b-8b8f-b9e7fab0136d" />
<img width="340" alt="스크린샷 2025-04-28 02 25 33" src="https://github.com/user-attachments/assets/bfc7f32e-2677-4bf1-a452-a66d70f72e7f" />

## 건의사항
- 고통은 우리를 더 강하게 만든다.......
