### PR TITLE
refactor: Simplify opacity logic using mapping array

### DIFF
--- a/src/components/FlashRun/FlashRunUser.tsx
+++ b/src/components/FlashRun/FlashRunUser.tsx
@@ -61,8 +61,13 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
   const [currentParticipantsNum, setCurrentParticipantsNum] =
     useState<number>(participantsNum); const [postCreatorId, setPostCreatorId] = useState<number | null>(null);
   const [postStatus, setPostStatus] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleStartClick = async () => {
+
+    if (isLoading) return;
+    setIsLoading(true);
+
     try {
       const token = JSON.parse(localStorage.getItem("accessToken") || "null");
       const response = await customAxios.patch(
@@ -82,6 +87,8 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
       }
     } catch (error) {
       setError("러닝 참여에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -107,7 +114,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
       );
 
       if (response.data.isSuccess) {
-        setUserStatus("ATTENDED"); 
+        setUserStatus("ATTENDED");
         setButtonText("출석완료");
         setError(null);
         setIsModalOpen(false);
@@ -601,6 +608,7 @@ const FlashRunUser: React.FC<FlashRunUserData> = ({
             <button
               className="w-full py-3 rounded-lg bg-[#366943] text-white text-lg mt-5"
               onClick={handleAttendanceClick}
+              disabled={isLoading}
             >
               확인
             </button>

--- a/src/components/NewRegularRun/NewRegularRunUser.tsx
+++ b/src/components/NewRegularRun/NewRegularRunUser.tsx
@@ -52,7 +52,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   const [refreshComments, setRefreshComments] = useState(false);
   const [userStatus, setUserStatus] = useState("");
 
-  const [buttonText, setButtonText] = useState("참여하기"); 
+  const [buttonText, setButtonText] = useState("참여하기");
   const [isGroupModalOpen, setIsGroupModalOpen] = useState(false);
   const [groupList, setGroupList] = useState<{ group: string; pace: string }[]>(
     [],
@@ -101,7 +101,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
         if (response.data.isSuccess) {
           const result = response.data.result;
 
-                    setTitle(result.title);
+          setTitle(result.title);
           setLocation(result.location);
           setDate(result.date);
           setContent(result.content);
@@ -140,7 +140,8 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
             );
             setIsGroupModalOpen(false);
           }
-          console.log(result.attachmentUrls);         }
+          console.log(result.attachmentUrls);
+        }
       } catch {
         setError("데이터 로딩 실패");
       }
@@ -169,7 +170,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
         );
       }
     } catch (error: any) {
-      console.error("❌ 참여/취소 요청 실패:", error);
+      console.error("참여/취소 요청 실패:", error);
 
       if (error?.response?.data) {
         const serverError = error.response.data;
@@ -218,20 +219,20 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
       if (res.data.isSuccess) {
         if (isCancel) {
-                    setUserStatus("");
+          setUserStatus("");
           setButtonText("참여하기");
           setSelectedGroup("");
           setIsGroupModalOpen(false);
           return;
         }
 
-                setUserStatus("PENDING");         setButtonText("출석하기");
-        setSelectedGroup(selectedGroup);         setIsGroupModalOpen(false);
+        setUserStatus("PENDING"); setButtonText("출석하기");
+        setSelectedGroup(selectedGroup); setIsGroupModalOpen(false);
       } else {
         setError(res.data.responseMessage);
       }
     } catch (error: any) {
-      console.error("❌ 참여/취소 요청 실패:", error);
+      console.error("참여/취소 요청 실패:", error);
       if (error?.response?.data) {
         setError(error.response.data.responseMessage || "참여 요청 실패");
       } else {
@@ -240,7 +241,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
     }
   };
 
-    const handleAttendanceClick = async () => {
+  const handleAttendanceClick = async () => {
     if (!code) return setError("출석 코드를 입력해주세요.");
     try {
       const token = JSON.parse(localStorage.getItem("accessToken") || "null");
@@ -280,23 +281,23 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   };
 
   const handleEditAttempt = () => {
-    const now = new Date();     const postDateKST = new Date(new Date(date).getTime() + 9 * 60 * 60 * 1000);
+    const now = new Date(); const postDateKST = new Date(new Date(date).getTime() + 9 * 60 * 60 * 1000);
 
     if (now < postDateKST) {
       alert("아직 명단 수정을 할 수 없습니다.");
       return;
     }
-        if (postStatus === "CANCELED") {
+    if (postStatus === "CANCELED") {
       alert("취소된 러닝은 명단을 수정할 수 없습니다.");
       return;
     }
 
-        if (userInfo.userRole === "ADMIN") {
+    if (userInfo.userRole === "ADMIN") {
       setIsEditMode(true);
       return;
     }
 
-        if (postStatus === "CLOSED") {
+    if (postStatus === "CLOSED") {
       alert("출석이 종료되어 명단 수정이 불가능합니다.");
       return;
     }
@@ -316,7 +317,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
     try {
       const endpoint =
         postStatus === "CLOSED" && userInfo.userRole === "ADMIN"
-          ? `/run/regular/post/${postId}/fix-attendance`           : `/run/regular/post/${postId}/manual-attendance`; 
+          ? `/run/regular/post/${postId}/fix-attendance` : `/run/regular/post/${postId}/manual-attendance`;
       await customAxios.patch(endpoint, payload, {
         headers: { Authorization: `${token}` },
       });
@@ -324,7 +325,8 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
       alert("출석 정보가 저장되었습니다.");
       setIsEditMode(false);
       setEditedAttendance({});
-      await fetchParticipantsInfo();     } catch {
+      await fetchParticipantsInfo();
+    } catch {
       alert("저장에 실패했습니다.");
     }
   };
@@ -530,14 +532,14 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
           <AttendanceList
             key={JSON.stringify(groupedParticipants)}
             groupedParticipants={groupedParticipants}
-                        isEditMode={isEditMode}
+            isEditMode={isEditMode}
             editedAttendance={editedAttendance}
             toggleAttendance={toggleAttendance}
             onSaveAttendance={saveAttendanceChanges}
             onToggleEditMode={handleEditAttempt}
-                        userInfoName={userInfo.userName}
+            userInfoName={userInfo.userName}
             postCreatorName={postCreatorName}
-                        canEdit={userInfo.userRole === "ADMIN"}
+            canEdit={userInfo.userRole === "ADMIN"}
           />
         )}
 
@@ -614,34 +616,33 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
 
                     const handleSelect = () => {
                       if (isSelected) {
-                        setSelectedGroup("");                       } else {
-                        setSelectedGroup(group.group);                       }
+                        setSelectedGroup("");
+                      } else {
+                        setSelectedGroup(group.group);
+                      }
                     };
 
                     return (
                       <button
                         key={index}
-                        className={`rounded-lg border flex items-center justify-between w-[230px] h-[48px] ${
-                          isSelected
+                        className={`rounded-lg border flex items-center justify-between w-[230px] h-[48px] ${isSelected
                             ? "bg-[#F3F8E8]"
                             : "bg-gray-100 hover:bg-gray-200"
-                        }`}
+                          }`}
                         onClick={handleSelect}
                       >
                         {/* 왼쪽: 그룹명 | 페이스 */}
                         <div className="flex items-center text-left">
                           <span
-                            className={`my-[16px] ml-[16px] font-bold text-base ${
-                              isSelected ? "text-black" : "text-gray-400"
-                            }`}
+                            className={`my-[16px] ml-[16px] font-bold text-base ${isSelected ? "text-black" : "text-gray-400"
+                              }`}
                           >
                             {group.group}
                           </span>
                           <div className="w-px h-[42px] ml-[16px] bg-gray-400" />
                           <span
-                            className={`text-[16px] font-semibold ml-[10px] ${
-                              isSelected ? "text-kuDarkGreen" : "text-gray-400"
-                            }`}
+                            className={`text-[16px] font-semibold ml-[10px] ${isSelected ? "text-kuDarkGreen" : "text-gray-400"
+                              }`}
                           >
                             {group.pace}
                           </span>
@@ -676,7 +677,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
           </div>
         )}
 
-       
+
         {isModalOpen && (
           <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-10">
             <div className="bg-white p-5 rounded-lg w-[280px] text-center relative">

--- a/src/components/NewRegularRun/NewRegularRunUser.tsx
+++ b/src/components/NewRegularRun/NewRegularRunUser.tsx
@@ -75,6 +75,9 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
     [userId: number]: boolean;
   }>({});
 
+  const [isLoading, setIsLoading] = useState(false);
+
+
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (
@@ -207,6 +210,10 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
   };
 
   const handleJoinConfirm = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+
     const isCancel = selectedGroup === "";
 
     try {
@@ -226,8 +233,10 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
           return;
         }
 
-        setUserStatus("PENDING"); setButtonText("출석하기");
-        setSelectedGroup(selectedGroup); setIsGroupModalOpen(false);
+        setUserStatus("PENDING");
+        setButtonText("출석하기");
+        setSelectedGroup(selectedGroup);
+        setIsGroupModalOpen(false);
       } else {
         setError(res.data.responseMessage);
       }
@@ -238,6 +247,8 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
       } else {
         setError("참여 요청 실패");
       }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -626,8 +637,8 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
                       <button
                         key={index}
                         className={`rounded-lg border flex items-center justify-between w-[230px] h-[48px] ${isSelected
-                            ? "bg-[#F3F8E8]"
-                            : "bg-gray-100 hover:bg-gray-200"
+                          ? "bg-[#F3F8E8]"
+                          : "bg-gray-100 hover:bg-gray-200"
                           }`}
                         onClick={handleSelect}
                       >
@@ -665,6 +676,7 @@ const NewRegularRunUser: React.FC<FlashRunUserData> = ({ postId }) => {
               <button
                 className="mt-5 w-full py-3 bg-kuDarkGreen text-white rounded-lg"
                 onClick={handleJoinConfirm}
+                disabled={isLoading}
               >
                 확인
               </button>

--- a/src/components/NewRegularRun/PacerCard.tsx
+++ b/src/components/NewRegularRun/PacerCard.tsx
@@ -17,7 +17,7 @@ const PacerCard: React.FC<PacerCardProps> = ({ pacers }) => {
     <div className="w-[335px] rounded-xl space-y-1">
       {/* 헤더 */}
       <div className="flex">
-        {/* 그룹 셀 (헤더용 더미 블럭) */}
+        {/* 그룹 셀 */}
         <div className="w-[52px] h-[52px] bg-[#F5F5F5] rounded-[10px]" />
 
         {/* 헤더 셀들 */}
@@ -38,14 +38,16 @@ const PacerCard: React.FC<PacerCardProps> = ({ pacers }) => {
 
       {/* 페이서 목록 */}
       {pacers.map((pacer, idx) => {
-        const opacity =
-          idx === 0
-            ? "bg-opacity-100"
-            : idx === 1
-              ? "bg-opacity-75"
-              : idx === 2
-                ? "bg-opacity-50"
-                : "bg-opacity-30";
+        const opacityMap = [
+          "bg-opacity-100",
+          "bg-opacity-80",
+          "bg-opacity-60",
+          "bg-opacity-40",
+          "bg-opacity-20",
+        ];
+
+        const opacity = opacityMap[idx] || "bg-opacity-20";
+
 
         return (
           <div key={idx} className="flex gap-x-[4px] items-center">


### PR DESCRIPTION
## 주요 변경사항 - ([0f76c87](https://github.com/bigcloud07/RIKU_fe_rel/pull/139/commits/0f76c8762306ed39b19445eb7f25a7789de6cc7d))
- 페이서 카드 D, E 그룹 opacity(투명도)가 동일한 경우 발견했고 값 수정
- 각 페이서 인덱스 마다 opacity를 3항 연산자를 중첩으로 사용한 부분을 가독성 및 유지보수를 위해 mapping array를 이용해서 코드를 수정했습니다.

## 스크린샷
<p align="center">
  <img src="https://github.com/user-attachments/assets/f451dd39-6cc2-49dc-9e0e-d82e123a759c" width="300" />
  <img src="https://github.com/user-attachments/assets/6749f40a-c4d1-48b5-be3d-8586bdf3ae08" width="300" />
</p>

<p align="center"><b>좌: 수정 전 / 우: 수정 후</b></p>


## 주요 리뷰 요청 사항
- 기존 3항 연산자 로직을 모두 제거했는데, 혹시 더 나은 방식이 있다면 알려주세요.
- 다른 컴포넌트에 주석 제거한 부분도 있는데 PacerCard 컴포넌트 부분만 봐주세용

